### PR TITLE
fix: 트랜스크립션의 문장이 시간순으로 정렬되어 저장되도록 수정

### DIFF
--- a/src/main/java/com/example/memic/transcription/domain/Sentence.java
+++ b/src/main/java/com/example/memic/transcription/domain/Sentence.java
@@ -14,7 +14,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @Getter
 @Setter
-public class Sentence {
+public class Sentence implements Comparable<Sentence> {
 
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
@@ -34,5 +34,10 @@ public class Sentence {
         if (content == null || content.isBlank()) {
             throw new InvalidTranscriptionException("스크립트 내용이 비어있습니다.");
         }
+    }
+
+    @Override
+    public int compareTo(Sentence o) {
+        return this.startPoint.compareTo(o.startPoint);
     }
 }

--- a/src/main/java/com/example/memic/transcription/domain/Transcription.java
+++ b/src/main/java/com/example/memic/transcription/domain/Transcription.java
@@ -21,27 +21,28 @@ import lombok.Setter;
 @Setter
 public class Transcription {
 
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Id
-    private Long id;
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Id
+  private Long id;
 
-    private String url;
+  private String url;
 
-    @OneToMany(cascade = CascadeType.PERSIST)
-    @JoinColumn(name = "transcription_id", updatable = false, nullable = false)
-    private List<Sentence> sentences;
+  @OneToMany(cascade = CascadeType.PERSIST)
+  @JoinColumn(name = "transcription_id", updatable = false, nullable = false)
+  private List<Sentence> sentences;
 
-    public Transcription(String url, Map<LocalTime, String> sentences) {
-        validate(url);
-        this.url = url;
-        this.sentences = sentences.entrySet().stream()
-                .map(entry -> new Sentence(entry.getKey(), entry.getValue()))
-                .toList();
+  public Transcription(String url, Map<LocalTime, String> sentences) {
+    validate(url);
+    this.url = url;
+    this.sentences = sentences.entrySet().stream()
+                              .map(entry -> new Sentence(entry.getKey(), entry.getValue()))
+                              .sorted()
+                              .toList();
+  }
+
+  private void validate(String url) {
+    if (!url.startsWith("https://")) {
+      throw new InvalidTranscriptionException("https 형식의 오디오 주소가 아닙니다.");
     }
-
-    private void validate(String url) {
-        if (!url.startsWith("https://")) {
-            throw new InvalidTranscriptionException("https 형식의 오디오 주소가 아닙니다.");
-        }
-    }
+  }
 }

--- a/src/main/java/com/example/memic/transcription/infrastructure/WhisperApiClient.java
+++ b/src/main/java/com/example/memic/transcription/infrastructure/WhisperApiClient.java
@@ -52,8 +52,7 @@ public class WhisperApiClient {
         body.add("model", "whisper-1");
         body.add("response_format", "srt");
 
-        HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body);
-        return requestEntity;
+      return new HttpEntity<>(body);
     }
 
     public String processTranscription(String transcription) {
@@ -76,7 +75,7 @@ public class WhisperApiClient {
     }
 
     private String formatTime(String time) {
-        return time.replaceFirst("^0", "").replaceAll(",\\d+$", "");
+        return time.replaceAll(",\\d+$", "");
     }
 
 

--- a/src/main/java/com/example/memic/transcription/infrastructure/WhisperApiClient.java
+++ b/src/main/java/com/example/memic/transcription/infrastructure/WhisperApiClient.java
@@ -83,7 +83,7 @@ public class WhisperApiClient {
         Map<LocalTime, String> logMap = new HashMap<>();
         String[] lines = text.split("\n");
 
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("H:mm:ss");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
 
         for (String line : lines) {
             String[] parts = line.split("]", 2);

--- a/src/test/java/com/example/memic/transcription/service/WhisperApiClientTest.java
+++ b/src/test/java/com/example/memic/transcription/service/WhisperApiClientTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+@SuppressWarnings("NonAsciiCharacters")
 @SpringBootTest
 class WhisperApiClientTest {
 
@@ -18,14 +19,14 @@ class WhisperApiClientTest {
     void 텍스트_파일을_파싱해서_시간과_문장으로_나눈다() {
         //given
         String text = """
-                [0:00:00]We didn't see any significant changes in the user metrics, but I think we should leave it for a week to get more data.
-                [0:00:05]Other than that, we talked to Legal about the other workstream, and it seems like they're backlogged, so they would have to revisit it in Q4, so we're blocked on that.
-                [0:00:15]Jomo, do you have any updates on the infowork?
-                [0:00:20]Nope. No updates for me.
-                [0:00:24]Okay. Yeah. Steve, do you have anything you want to add to what we just said?
-                [0:00:29]Sorry about that. I had to do something.
-                [0:00:33]Oh, yeah? Well, I f***ed your mom last night.
-                [0:00:36]Sorry, Jomo. What did you say?
+                [00:00:00]We didn't see any significant changes in the user metrics, but I think we should leave it for a week to get more data.
+                [00:00:05]Other than that, we talked to Legal about the other workstream, and it seems like they're backlogged, so they would have to revisit it in Q4, so we're blocked on that.
+                [00:00:15]Jomo, do you have any updates on the infowork?
+                [00:00:20]Nope. No updates for me.
+                [00:00:24]Okay. Yeah. Steve, do you have anything you want to add to what we just said?
+                [00:00:29]Sorry about that. I had to do something.
+                [00:00:33]Oh, yeah? Well, I f***ed your mom last night.
+                [00:00:36]Sorry, Jomo. What did you say?
                 """;
 
         //when

--- a/src/test/java/com/example/memic/transcription/ui/TranscriptionIntegrationTest.java
+++ b/src/test/java/com/example/memic/transcription/ui/TranscriptionIntegrationTest.java
@@ -66,6 +66,6 @@ class TranscriptionIntegrationTest {
         transcriptionResponseFromGet.sentences().forEach(e -> System.out.println(e.startPoint()));
 
         assertThat(transcriptionResponseFromPost).isEqualTo(transcriptionResponseFromGet);
-        assertThat(transcriptionResponseFromPost.sentences()).isSortedAccordingTo(Comparator.comparing(SentenceResponse::sentence));
+        assertThat(transcriptionResponseFromPost.sentences()).isSortedAccordingTo(Comparator.comparing(SentenceResponse::startPoint));
     }
 }

--- a/src/test/java/com/example/memic/transcription/ui/TranscriptionIntegrationTest.java
+++ b/src/test/java/com/example/memic/transcription/ui/TranscriptionIntegrationTest.java
@@ -7,9 +7,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.example.memic.transcription.dto.SentenceResponse;
 import com.example.memic.transcription.dto.TranscriptionCreateRequest;
 import com.example.memic.transcription.dto.TranscriptionResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Comparator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -61,6 +63,9 @@ class TranscriptionIntegrationTest {
                 TranscriptionResponse.class
         );
 
+        transcriptionResponseFromGet.sentences().forEach(e -> System.out.println(e.startPoint()));
+
         assertThat(transcriptionResponseFromPost).isEqualTo(transcriptionResponseFromGet);
+        assertThat(transcriptionResponseFromPost.sentences()).isSortedAccordingTo(Comparator.comparing(SentenceResponse::sentence));
     }
 }


### PR DESCRIPTION
### 😋 작업한 내용
- Transcription 객체가 생성될 때, Sentence 객체들의 리스트를 시간순으로 정렬하여 저장하도록 수정하였습니다.
- IntegrationTest에서 시간순으로 정렬되어 응답이 전달되는지 확인하는 코드를 추가하였습니다.

### 👍 관련 이슈

Resolved : #5